### PR TITLE
allow access to files in $HOME

### DIFF
--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=x11
   - --device=dri
   - --filesystem=/tmp
+  - --filesystem=host
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
While the permission system already allows openning files from the app menu or from the file manager, it currently does not allow to open files by drag&droppping them into the app. Allowing access to $HOME works around this issue.