### PR TITLE
enable Wayland with X11 fallback

### DIFF
--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -46,9 +46,8 @@ modules:
   - name: Boost
     buildsystem: simple
     build-commands:
-      - ./bootstrap.sh --prefix=/app
-      - ./b2 install --build-type=complete link=shared --layout=versioned runtime-link=shared
-        cxxflags="$CXXFLAGS" linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
+      - ./bootstrap.sh --prefix=/app --with-libraries=filesystem,regex
+      - ./b2 install link=static runtime-link=static cxxflags="-fPIC" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
         url: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2

--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -5,10 +5,10 @@ runtime-version: '5.15'
 command: meshlab
 rename-desktop-file: meshlab.desktop
 rename-icon: meshlab
-# Wayland does not work https://github.com/cnr-isti-vclab/meshlab/issues/738
 finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
-  - --socket=x11
   - --device=dri
   - --filesystem=/tmp
   - --filesystem=home

--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -33,6 +33,9 @@ modules:
   - name: MPFR
     buildsystem: autotools
     builddir: true
+    config-opts:
+      - --disable-shared
+      - --with-pic
     sources:
       - type: archive
         url: https://www.mpfr.org/mpfr-current/mpfr-4.1.0.tar.xz

--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -102,7 +102,7 @@ modules:
 
   - name: gmp
     config-opts:
-      - --prefix=/app
+      - --disable-shared
     sources:
       - type: archive
         url: https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz

--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -94,6 +94,9 @@ modules:
 
   - name: lib3ds
     buildsystem: autotools
+    config-opts:
+      - --disable-shared
+      - --with-pic
     sources:
       - type: archive
         url: https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/lib3ds/lib3ds-1.3.0.zip

--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -18,11 +18,14 @@ cleanup:
   - /include
   - /lib/cmake
   - /lib/pkgconfig
+  - /lib/debug
   - /share/doc
   - /share/man
   - /bin/rbox
   - /bin/q*
   - /bin/3dsdump
+  - /bin/lib3ds-*
+  - /bin/cgal_*
   - '*.la'
   - '*.a'
 


### PR DESCRIPTION
The Wayland related crash that was originally reported as https://github.com/cnr-isti-vclab/meshlab/issues/738 was fixed in https://github.com/cnr-isti-vclab/meshlab/pull/1104. I am able to build and run the latest release (2021.10) in a nested Wayland session.

With this change, MeshLab will still start as X11 client. Using Wayland can be enforced either by setting environment variable `QT_QPA_PLATFORM=wayland` or via the command line argument `-platform wayland`. But in either case, this will not fallback automatically to X11.

I also added a couple of other changes to reduce the size from 59.5 to 36.4 MB and the build time from 3 hours (!!!) to 15 minutes.