### PR TITLE
update runtime to 5.15-21.08

### DIFF
--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -1,7 +1,7 @@
 app-id: net.meshlab.MeshLab
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 command: meshlab
 rename-desktop-file: meshlab.desktop
 rename-icon: meshlab


### PR DESCRIPTION
The runtime `org.kde.Platform` version `5.15` is deprecated.