### PR TITLE
allow GVfs mounts

### DIFF
--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=host #https://github.com/cnr-isti-vclab/meshlab/issues/1103
   - --filesystem=/run/media
   - --filesystem=/media
+  - --filesystem=xdg-run/gvfs # allow GVfs mounts
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
Allow access to GVfs mounts on `/run/user/$USER/gvfs`.