### PR TITLE
update KDE SDK

### DIFF
--- a/net.meshlab.MeshLab.yaml
+++ b/net.meshlab.MeshLab.yaml
@@ -1,7 +1,7 @@
 app-id: net.meshlab.MeshLab
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-23.08
+runtime-version: 5.15-24.08
 command: meshlab
 rename-desktop-file: meshlab.desktop
 rename-icon: meshlab


### PR DESCRIPTION
`org.kde.Platform` version `5.15-23.08` is end-of-life. I am getting the following warning when updating flatpaks:
```
Info: runtime org.kde.Platform branch 5.15-23.08 is end-of-life, with reason:
   We strongly recommend moving to the latest Qt 5.15-based stable version of the Platform and SDK
Info: applications using this runtime:
   net.meshlab.MeshLab
```